### PR TITLE
Add swap file option

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -29,7 +29,7 @@ export default {
         LUKS_PASSWORD: undefined,
         HOSTNAME: "debian",
         TIMEZONE: "UTC",
-        ENABLE_SWAP: true,
+        ENABLE_SWAP: "partition",
         SWAP_SIZE: 1,
       }
     }
@@ -271,11 +271,15 @@ export default {
             <option v-for="item in timezones" :value="item">{{ item }}</option>
         </select>
 
-        <input type="checkbox" id="ENABLE_SWAP" v-model="installer.ENABLE_SWAP" class="inline mt-2" :disabled="running">
-        <label for="ENABLE_SWAP" class="inline mt-2">Enable Swap</label>
+        <label for="ENABLE_SWAP">Swap Space</label>
+        <select id="ENABLE_SWAP" v-model="installer.ENABLE_SWAP" :disabled="running">
+          <option value="none" selected>None</option>
+          <option value="partition" selected>Partition</option>
+          <option value="file" selected>File</option>
+        </select>
 
         <label for="SWAP_SIZE">Swap Size (GB)</label>
-        <input type="number" id="SWAP_SIZE" v-model="installer.SWAP_SIZE" :disabled="!installer.ENABLE_SWAP || running">
+        <input type="number" id="SWAP_SIZE" v-model="installer.SWAP_SIZE" :disabled="installer.ENABLE_SWAP == 'none' || running">
       </fieldset>
 
       <fieldset>

--- a/installer.sh
+++ b/installer.sh
@@ -29,6 +29,11 @@ FSFLAGS="compress=zstd:1"
 DEBIAN_FRONTEND=noninteractive
 export DEBIAN_FRONTEND
 
+if [ "$(id -u)" -ne 0 ]; then
+    echo 'This script must be run by root' >&2
+    exit 1
+fi
+
 if [ x"${NON_INTERACTIVE}" == "x" ]; then
     notify install required packages
     apt-get update -y

--- a/installer.sh
+++ b/installer.sh
@@ -10,7 +10,7 @@ ROOT_PASSWORD=changeme
 LUKS_PASSWORD=luke
 DEBIAN_VERSION=bookworm
 HOSTNAME=debian12
-ENABLE_SWAP=true
+ENABLE_SWAP=partition
 SWAP_SIZE=2
 fi
 
@@ -72,7 +72,7 @@ kernel_params="luks.options=tpm2-device=auto rw quiet rootfstype=btrfs rootflags
 efi_partition=/dev/disk/by-partuuid/${efi_part_uuid}
 root_partition=/dev/disk/by-partuuid/${luks_part_uuid}
 
-if [ ${ENABLE_SWAP} == "true" ]; then
+if [ ${ENABLE_SWAP} == "partition" ]; then
 swap_part_uuid=$(cat swap-part.uuid)
 swap_size_blocks=$((${SWAP_SIZE}*2048*1024))
 root_start_blocks=$((2099200+${swap_size_blocks}))
@@ -121,7 +121,7 @@ function wait_for_file {
 }
 
 wait_for_file ${root_partition}
-if [ ${ENABLE_SWAP} == "true" ]; then
+if [ ${ENABLE_SWAP} == "partition" ]; then
   wait_for_file ${swap_partition}
 fi
 
@@ -185,7 +185,7 @@ if [ ! -f vfat_created.txt ]; then
     touch vfat_created.txt
 fi
 
-if [ ${ENABLE_SWAP} == "true" ]; then
+if [ ${ENABLE_SWAP} == "partition" ]; then
 setup_luks ${swap_partition}
 swap_uuid=$(cat luks.uuid)
 
@@ -200,7 +200,7 @@ notify making swap
 mkswap /dev/mapper/${swap_device}
 swapon /dev/mapper/${swap_device}
 
-fi  # swap enabled
+fi  # swap as partition
 
 if grep -qs "${top_level_mount}" /proc/mounts ; then
     echo top-level subvolume already mounted on ${top_level_mount}
@@ -215,6 +215,11 @@ if [ ! -e ${top_level_mount}/@ ]; then
     notify create @ and @home subvolumes on ${top_level_mount}
     btrfs subvolume create ${top_level_mount}/@
     btrfs subvolume create ${top_level_mount}/@home
+    if [ ${ENABLE_SWAP} == "file" ]; then
+        notify create @swap subvolume for swap file on ${top_level_mount}
+        btrfs subvolume create ${top_level_mount}/@swap
+        chmod 700 ${top_level_mount}/@swap
+    fi
     btrfs subvolume set-default ${top_level_mount}/@
 fi
 
@@ -226,6 +231,17 @@ else
     mount ${root_device} ${target} -o ${FSFLAGS},subvol=@
     mkdir -p ${target}/home
     mount ${root_device} ${target}/home -o ${FSFLAGS},subvol=@home
+    if [ ${ENABLE_SWAP} == "file" ]; then
+        notify mount swap subvolume on ${target}
+        mkdir -p ${target}/swap
+        mount ${root_device} ${target}/swap -o noatime,subvol=@swap
+    fi
+fi
+
+if [ ${ENABLE_SWAP} == "file" ]; then
+    notify make swap file at ${target}/swap/swapfile
+    btrfs filesystem mkswapfile --size ${SWAP_SIZE}G ${target}/swap/swapfile
+    swapon ${target}/swap/swapfile
 fi
 
 if [ ! -f ${target}/etc/debian_version ]; then
@@ -266,9 +282,15 @@ UUID=${btrfs_uuid} /home btrfs defaults,subvol=@home,${FSFLAGS} 0 1
 UUID=${btrfs_uuid} /root/btrfs1 btrfs defaults,subvolid=5,${FSFLAGS} 0 1
 PARTUUID=${efi_part_uuid} /boot/efi vfat defaults 0 2
 EOF
-if [ ${ENABLE_SWAP} == "true" ]; then
+
+if [ ${ENABLE_SWAP} == "partition" ]; then
 cat <<EOF >> ${target}/etc/fstab
 /dev/mapper/${swap_device} swap swap defaults 0 0
+EOF
+elif [ ${ENABLE_SWAP} == "file" ]; then
+cat <<EOF >> ${target}/etc/fstab
+UUID=${btrfs_uuid} /swap btrfs defaults,subvol=@swap,noatime 0 0
+/swap/swapfile none swap defaults 0 0
 EOF
 fi
 
@@ -319,7 +341,7 @@ cat <<EOF > ${target}/etc/kernel/cmdline
 ${kernel_params}
 EOF
 
-if [ ${ENABLE_SWAP} == "true" ]; then
+if [ ${ENABLE_SWAP} == "partition" ]; then
 cat <<EOF > ${target}/etc/dracut.conf.d/90-hibernate.conf
 add_dracutmodules+=" resume "
 EOF
@@ -411,15 +433,17 @@ notify reverting backports apt-pin
 rm -f ${target}/etc/apt/preferences.d/99backports-temp
 
 notify umounting all filesystems
+if [ ${ENABLE_SWAP} == "partition" ]; then
+  swapoff /dev/mapper/${swap_device}
+elif [ ${ENABLE_SWAP} == "file" ]; then
+  swapoff ${target}/swap/swapfile
+fi
 umount -R ${target}
 umount -R ${top_level_mount}
-if [ ${ENABLE_SWAP} == "true" ]; then
-  swapoff /dev/mapper/${swap_device}
-fi
 
 notify closing luks
 cryptsetup luksClose ${luks_device}
-if [ ${ENABLE_SWAP} == "true" ]; then
+if [ ${ENABLE_SWAP} == "partition" ]; then
   cryptsetup luksClose /dev/mapper/${swap_device}
 fi
 

--- a/installer.sh
+++ b/installer.sh
@@ -156,6 +156,7 @@ function setup_luks {
 }
 
 setup_luks ${root_partition}
+root_uuid=$(cat luks.uuid)
 
 if [ ! -e ${root_device} ]; then
     notify open luks on root
@@ -242,6 +243,8 @@ if [ ${ENABLE_SWAP} == "file" ]; then
     notify make swap file at ${target}/swap/swapfile
     btrfs filesystem mkswapfile --size ${SWAP_SIZE}G ${target}/swap/swapfile
     swapon ${target}/swap/swapfile
+    swapfile_offset=$(btrfs inspect-internal map-swapfile -r ${target}//swap/swapfile)
+    kernel_params="${kernel_params} luks.name=${root_uuid}=${luks_device} resume=${root_device} resume_offset=${swapfile_offset}"
 fi
 
 if [ ! -f ${target}/etc/debian_version ]; then


### PR DESCRIPTION
* Allow to optionally create a swap file instead of a swap partition. It's in a subpartition, so timeshift snapshots work. User can select file or partition mode through a drop-down menu in the UI.
* Also ensure installer script is run by root.

I have tested the web frontend alone and the swap file creation by running the installer script directly on a VM. I haven't tested it together though as I haven't succeeded yet in creating an effective test setup for that.