### PR TITLE
Add Headless Option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Opinionated Debian Installer
 
-This tool can be used to create a modern installation of Debian. 
+This tool can be used to create a modern installation of Debian.
 Our opinions of what a modern installation of Debian should look like in 2024 are as follows:
 
  - Debian 12 (Bookworm)
@@ -10,13 +10,13 @@ Our opinions of what a modern installation of Debian should look like in 2024 ar
  - Full disk encryption, unlocked by TPM
  - Fast installation using an image
  - Browser-based installer
-  
+
 ## Limitations
 
  - **The installer will take over your whole disk**
  - Amd64 with EFI only
  - The installer is in english only
- - Secure boot is not supported 
+ - Secure boot is not supported
 
 ## Downloads
 
@@ -29,7 +29,7 @@ Our opinions of what a modern installation of Debian should look like in 2024 ar
 ## Instructions
 
 1. Download one of the live image files from the table above
-2. Write the image file to a USB flash drive. **Do not use ventoy** or similar "clever" tools - they are not compatible with these images. If you need a GUI, use [etcher](https://github.com/balena-io/etcher/releases) or [win32DiskImager](https://sourceforge.net/projects/win32diskimager/files/Archive/) or just use dd - `dd if=opinionated-debian-installer*.img of=/dev/sdX bs=8MB status=progress conv=sync` where sdX is your USB flash drive 
+2. Write the image file to a USB flash drive. **Do not use ventoy** or similar "clever" tools - they are not compatible with these images. If you need a GUI, use [etcher](https://github.com/balena-io/etcher/releases) or [win32DiskImager](https://sourceforge.net/projects/win32diskimager/files/Archive/) or just use dd - `dd if=opinionated-debian-installer*.img of=/dev/sdX bs=8MB status=progress conv=sync` where sdX is your USB flash drive
 3. Boot from the USB flash drive
 4. Start the installer icon from the desktop/dash, fill in the form in the browser and press the big _Install_ button
 5. Reboot and enjoy
@@ -46,7 +46,7 @@ Screenshot of the full installer GUI:
 
 ## Details
 
-- GPT disk partitions are created on the designated disk drive: 
+- GPT disk partitions are created on the designated disk drive:
   - UEFI ESP partition
   - Optional swap partition - LUKS encrypted
   - Root partition - [LUKS](https://cryptsetup-team.pages.debian.net/cryptsetup/README.Debian.html) encrypted (rest of the drive)
@@ -57,7 +57,7 @@ Screenshot of the full installer GUI:
 - [Systemd-boot](https://www.freedesktop.org/wiki/Software/systemd/systemd-boot/) is used instead of grub
 - [Network-manager](https://wiki.debian.org/NetworkManager) is used for networking
 - [Systemd-cryptenroll](https://www.freedesktop.org/software/systemd/man/systemd-cryptenroll.html#--tpm2-device=PATH) is used to unlock the disk, using TPM (if available)
-- [Sudo](https://wiki.debian.org/sudo) is installed and configured for the created user 
+- [Sudo](https://wiki.debian.org/sudo) is installed and configured for the created user
 
 ## (Optional) Configuration, Automatic Installation
 
@@ -74,7 +74,7 @@ You can use the installer for server installation.
 As a start, edit the configuration file installer.ini (see above), set option BACK_END_IP_ADDRESS to 0.0.0.0 and reboot the installer.
 **There is no encryption or authentication in the communication so only do this on a trusted network.**
 
-You have several options to access the installer. 
+You have several options to access the installer.
 Assuming the IP address of the installed machine is 192.168.1.29 and you can reach it from your PC:
 
 * Use the web interface in a browser on a PC - open `http://192.168.1.29/opinionated-debian-installer/`
@@ -82,7 +82,7 @@ Assuming the IP address of the installed machine is 192.168.1.29 and you can rea
 * Use curl - again, see the [installer.ini](installer-files/boot/efi/installer.ini) file for list of all options for the form data in -F parameters:
 
       curl -v -F "DISK=/dev/vda" -F "USER_PASSWORD=hunter2" \
-      -F "ROOT_PASSWORD=changeme" -F "LUKS_PASSWORD=luke" \ 
+      -F "ROOT_PASSWORD=changeme" -F "LUKS_PASSWORD=luke" \
       http://192.168.1.29:5000/install
 
 * Use curl to prompt for logs:
@@ -111,7 +111,7 @@ Attach the downloaded installer image file as _Device type: Disk device_, not ~~
 
 ### Hyper-V
 
-To test with the MS hyper-v virtualization, make sure to create your VM with [Generation 2](https://learn.microsoft.com/en-us/windows-server/virtualization/hyper-v/plan/Should-I-create-a-generation-1-or-2-virtual-machine-in-Hyper-V). 
+To test with the MS hyper-v virtualization, make sure to create your VM with [Generation 2](https://learn.microsoft.com/en-us/windows-server/virtualization/hyper-v/plan/Should-I-create-a-generation-1-or-2-virtual-machine-in-Hyper-V).
 This will enable UEFI.
 TPM can be enabled and Secure Boot disabled in the Security tab of the Hyper-V settings.
 
@@ -142,14 +142,14 @@ In the first stage of image generation, you will get a _tasksel_ prompt where yo
 There are 3 GPT partitions on the installer image:
 
  1. EFI boot partition
- 2. Base Image - Btrfs partition with maximum zstd compression. 
-    When the live system is running, this is used as a [read-only lower device for overlayfs](https://docs.kernel.org/filesystems/overlayfs.html). 
+ 2. Base Image - Btrfs partition with maximum zstd compression.
+    When the live system is running, this is used as a [read-only lower device for overlayfs](https://docs.kernel.org/filesystems/overlayfs.html).
     When installing the target system, the installer will copy this to the target system, mount it read-write, resize to expand to the whole partition and continue with the system installation.
  3. Top Overlay - upper and work device for the overlayfs for the live system. The changes you make while the live system is running are persisted here.
 
 ### Building the Front-End
 
-The front-end is a [vue](https://vuejs.org/) application. 
+The front-end is a [vue](https://vuejs.org/) application.
 You need [npm](https://www.npmjs.com/) to build it.
 Run the following commands to build it:
 
@@ -210,4 +210,3 @@ The following table contains comparison of features between our opinionated debi
 [3] `@rootfs`
 
 [4] Fixed partitioning (see Details above), LUKS is automatic, BTRFS is used as filesystem
-

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Assuming the IP address of the installed machine is 192.168.1.29 and you can rea
 * Use the text mode interface - start `opinionated-installer-tui -baseUrl http://192.168.1.29:5000`
 * Use curl - again, see the [installer.ini](installer-files/boot/efi/installer.ini) file for list of all options for the form data in -F parameters:
 
-      curl -v -F "DISK=/dev/vda" -F "USER_PASSWORD=hunter2" \
+      curl -v -F "HEADLESS="y" -F "DISK=/dev/vda" -F "USER_PASSWORD=hunter2" \
       -F "ROOT_PASSWORD=changeme" -F "LUKS_PASSWORD=luke" \
       http://192.168.1.29:5000/install
 

--- a/frontend-tui/frontend_test.go
+++ b/frontend-tui/frontend_test.go
@@ -56,4 +56,3 @@ func TestGetSliceIndex(t *testing.T) {
 		t.Errorf("Slice index = %d; want %d", o, 2)
 	}
 }
-

--- a/frontend-tui/main.go
+++ b/frontend-tui/main.go
@@ -3,11 +3,12 @@ package main
 import (
 	"flag"
 	"fmt"
-	"github.com/gdamore/tcell/v2"
-	"github.com/rivo/tview"
 	"io"
 	"net/url"
 	"strconv"
+
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
 )
 
 func LOG(l io.Writer, format string, args ...any) {

--- a/frontend-tui/rest.go
+++ b/frontend-tui/rest.go
@@ -62,6 +62,7 @@ func processOutput(baseUrl *url.URL, log io.Writer) {
 func (m *Model) startInstallation(baseUrl *url.URL, log io.Writer) error {
 	post := url.Values{}
 
+	post.Set("HEADLESS", "yes")
 	post.Set("DISK", m.Disk)
 	post.Set("DEBIAN_VERSION", m.DebianVersion)
 	post.Set("USERNAME", m.Username)

--- a/frontend-tui/rest.go
+++ b/frontend-tui/rest.go
@@ -2,10 +2,11 @@ package main
 
 import (
 	"fmt"
-	"golang.org/x/net/websocket"
 	"io"
 	"net/http"
 	"net/url"
+
+	"golang.org/x/net/websocket"
 )
 
 func loginToBackend(baseUrl *url.URL) (Model, error) {

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -17,7 +17,7 @@ export default {
       finished: false,
       output_reader_connection: null,
       timezones: [],
-      
+
       // values for the installer:
       installer: {
         DISK: undefined,
@@ -81,7 +81,7 @@ export default {
               this.installer[key] = response.environ[key];
             }
           }
-          
+
           this.get_block_devices();
           this.read_process_output();
 
@@ -162,7 +162,7 @@ export default {
         .then(result => {
             console.debug(result);
             this.finished = false;
-            
+
         })
         .catch(error => {
             this.running = false;

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -20,6 +20,7 @@ export default {
 
       // values for the installer:
       installer: {
+        HEADLESS: undefined,
         DISK: undefined,
         USERNAME: undefined,
         USER_FULL_NAME: undefined,
@@ -301,6 +302,9 @@ export default {
 
         <label for="SWAP_SIZE">Swap Size (GB)</label>
         <input type="number" id="SWAP_SIZE" v-model="installer.SWAP_SIZE" :disabled="installer.ENABLE_SWAP == 'none' || running">
+
+        <label for="HEADLESS">Headless/Server Install</label>
+        <input type="checkbox" id="HEADLESS">
       </fieldset>
 
       <fieldset>
@@ -363,7 +367,7 @@ a,
   color: #cd130f;
 }
 
-input:not(.inline), select, textarea {
+input:not(.inline):not([type='checkbox']), select, textarea {
   width: 100%;
 }
 


### PR DESCRIPTION
Server installs require a different set of software preinstalled. 

For now the `HEADLESS` option can be set in the html UI, but the TUI always enables it by default. What's best here?

I think it would be also interesting to enable it on the server image by default, but not on the workstation images, if that's possible.

Overall my idea is to use this together with an Ansible role [like this](https://github.com/romangg/ansible-role-odin) so installs can be done quickly from a generic Debian live image on new servers.