### PR TITLE
docs: lightweight alternative to Balena Etcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Our opinions of what a modern installation of Debian should look like in 2025 ar
 ## Instructions
 
 1. Download one of the live image files from the table above
-2. Write the image file to a USB flash drive. **Do not use ventoy** or similar "clever" tools - they are not compatible with these images. If you need a GUI, use [etcher](https://github.com/balena-io/etcher/releases) or [win32DiskImager](https://sourceforge.net/projects/win32diskimager/files/Archive/) or just use dd - `dd if=opinionated-debian-installer*.img of=/dev/sdX bs=256M oflag=dsync status=progress` where sdX is your USB flash drive
+2. Write the image file to a USB flash drive. **Do not use ventoy** or similar "clever" tools - they are not compatible with these images. If you need a GUI, use [etcher](https://github.com/balena-io/etcher/releases), [fedora media writer](https://flathub.org/en/apps/org.fedoraproject.MediaWriter) or [win32DiskImager](https://sourceforge.net/projects/win32diskimager/files/Archive/) or just use dd - `dd if=opinionated-debian-installer*.img of=/dev/sdX bs=256M oflag=dsync status=progress` where sdX is your USB flash drive
 3. Boot from the USB flash drive
 4. Start the installer icon from the desktop/dash, fill in the form in the browser and press the big _Install_ button
 5. (If you are using the fully authenticated boot mode: Reboot, enroll your MOK and reboot again)


### PR DESCRIPTION
Hi,

I’ve been distro-hopping more than four times over the past couple of months. I usually rely on Ventoy as my go-to, but lately I’ve run into issues where some distros wouldn’t boot. Most of the time, the problem happens during the copy process, so I have to carefully eject the flash drive only after Nautilus says it’s safe, then double-check the checksum on the drive.

Out of frustration, I tried Fedora Media Writer. I’ve tested it multiple times now, and so far I haven’t had any issues.

