### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,8 @@
 name: Unit test and build compiled components
 
+permissions:
+  contents: read
+
 on:  [push, pull_request]
 
 jobs:


### PR DESCRIPTION
Potential fix for [https://github.com/r0b0/debian-installer/security/code-scanning/2](https://github.com/r0b0/debian-installer/security/code-scanning/2)

To fix the problem, you should add an explicit `permissions` block to the workflow file. This block can be added either at the root level (applies to all jobs) or within each job definition (if different jobs need distinct permissions). For these jobs, the minimal required permission is likely `contents: read`, unless a step requires writing to pull requests or issues (none are seen). Add the following snippet near the top of the workflow (just below the `name:` and before `jobs:`), to apply it to all jobs:

```yaml
permissions:
  contents: read
```

No other files need to be changed; this is a YAML config fix in `.github/workflows/build.yml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
