### PR TITLE
Make 32 bit support optional

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -128,7 +128,7 @@ EOF
 cat <<EOF > repart.d/02_root.conf
 [Partition]
 Type=root
-Label=Debian ${DEBIAN_VERSION}
+Label=Debian
 UUID=${main_part_uuid}
 Format=btrfs
 MakeDirectories=/@home


### PR DESCRIPTION
It would be useful to make it eligible if you want to have 32-bit support or not. Many of these useful 32-bit libraries for Steam, Wine or Proton... can be isolated with the Flatpak sandbox. On the other hand, installing fewer packages at the OS level reduces the attack surface.