### PR TITLE
Fix kernel boot issues with LUKS encryption

### DIFF
--- a/installer-files/etc/dracut.conf.d/10-no-hostonly.conf
+++ b/installer-files/etc/dracut.conf.d/10-no-hostonly.conf
@@ -1,0 +1,3 @@
+# Build full initramfs with all drivers instead of host-only
+# This ensures the initramfs works across different hardware configurations
+hostonly="no"


### PR DESCRIPTION
### Problem
When installing kernels via Debian packages on systems with LUKS encryption, the generated UKI (Unified Kernel Image) would fail to boot with errors like:
- "Dependency failed for initrd-root-fs.target - Initrd Root File System"
- "Cannot open access to console, the root account is locked"

This was caused by two issues:
1. Missing LUKS parameters in kernel cmdline (`rd.luks.uuid`, `rd.luks.name`, `root=`)
2. Dracut building host-only initramfs by default, missing critical drivers

### Solution
1. **Add dracut configuration** (`/etc/dracut.conf.d/10-no-hostonly.conf`):
   - Forces dracut to build full initramfs with all drivers instead of host-only
   - Ensures compatibility across different hardware and kernel versions

2. **Fix kernel cmdline generation** in `installer.sh`:
   - Add `rd.luks.uuid=<uuid>` - specifies which LUKS device to unlock
   - Add `rd.luks.name=<uuid>=root` - maps LUKS device to /dev/mapper/root
   - Add `root=/dev/mapper/root` - specifies root filesystem location
   - Keep `rd.luks.options=tpm2-device=auto` for TPM2 auto-unlock
   - Also fixes non-LUKS installations by adding `root=` parameter

### Testing
Tested on Debian sid with:
- LUKS2 encryption + TPM2 auto-unlock
- btrfs with subvolumes
- systemd-boot + UKI
- MOK signing for Secure Boot
- Kernel upgrade from 6.16.12 to 6.17.8

### Result
New kernel installations now boot successfully without manual intervention.